### PR TITLE
refactor(init): remove stub profile::mod function

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -41,19 +41,3 @@ p6df::modules::jupyter::langs() {
 
   p6_return_void
 }
-
-######################################################################
-#<
-#
-# Function: words jupyter $JUPYTER_PATH = p6df::modules::jupyter::profile::mod()
-#
-#  Returns:
-#	words - jupyter $JUPYTER_PATH
-#
-#  Environment:	 JUPYTER_PATH
-#>
-######################################################################
-p6df::modules::jupyter::profile::mod() {
-
-  p6_return_words 'jupyter' "$"
-}


### PR DESCRIPTION
## What
Remove the stub `p6df::modules::jupyter::profile::mod()` function that returned an incomplete/broken value (`"$"` instead of an actual env var).

## Why
The function was a dead stub with a malformed return value and no real implementation. Removing it cleans up the module and prevents accidental usage of broken code.

## Test plan
- Reviewed diff confirms only the stub function block is removed
- No callers of this function exist in the codebase

## Dependencies
None