### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,23 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::jupyter::deps()
+#
+#>
+######################################################################
 p6df::modules::jupyter::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-python
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jupyter::langs()
+#
+#>
 ######################################################################
 p6df::modules::jupyter::langs() {
 
@@ -16,6 +28,12 @@ p6df::modules::jupyter::langs() {
   p6_return_void
 }
 ######################################################################
+#<
+#
+# Function: p6df::modules::jupyter::vscodes()
+#
+#>
+######################################################################
 p6df::modules::jupyter::vscodes() {
 
   p6df::modules::vscode::extension::install ms-toolsai.jupyter
@@ -23,21 +41,3 @@ p6df::modules::jupyter::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::jupyter::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jupyter::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jupyter::langs()
-#
-#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::jupyter::deps()
-#
-#>
-######################################################################
 p6df::modules::jupyter::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-python
@@ -13,11 +7,14 @@ p6df::modules::jupyter::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::jupyter::vscodes()
-#
-#>
+p6df::modules::jupyter::langs() {
+
+  uv tool install jupyterlab
+  uv tool install notebook
+  uv tool install voila
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::jupyter::vscodes() {
 
@@ -29,15 +26,18 @@ p6df::modules::jupyter::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jupyter::langs()
+# Function: p6df::modules::jupyter::deps()
 #
 #>
 ######################################################################
-p6df::modules::jupyter::langs() {
-
-  uv tool install jupyterlab
-  uv tool install notebook
-  uv tool install voila
-
-  p6_return_void
-}
+#<
+#
+# Function: p6df::modules::jupyter::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jupyter::langs()
+#
+#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None